### PR TITLE
fix(file-uploader-inline): add `flex: 1` css property to fill all available space inside flex column container

### DIFF
--- a/blocks/test/raw-inline.htm
+++ b/blocks/test/raw-inline.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <base href="../../" />
 
 <head>

--- a/blocks/test/raw-minimal.htm
+++ b/blocks/test/raw-minimal.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <base href="../../" />
 
 <head>

--- a/blocks/test/raw-regular.htm
+++ b/blocks/test/raw-regular.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <base href="../../" />
 
 <head>

--- a/solutions/file-uploader/inline/index.css
+++ b/solutions/file-uploader/inline/index.css
@@ -1,5 +1,9 @@
 @import url('../../../blocks/themes/lr-basic/index.css');
 
+:host {
+  flex: 1;
+}
+
 lr-start-from {
   height: 100%;
 }


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
