### PR TITLE
fix(file-item): do not validate local files if no mime type provided (this is the case for drag'n'dropped HEICs)

### DIFF
--- a/blocks/FileItem/FileItem.js
+++ b/blocks/FileItem/FileItem.js
@@ -263,14 +263,19 @@ export class FileItem extends UploaderBlock {
     });
 
     this._subEntry('isImage', (isImage) => {
-      let imagesOnly = this.getCssData('--cfg-img-only');
-      if (entry.getValue('externalUrl') && !entry.getValue('uuid') && imagesOnly && !isImage) {
-        // don't validate not uploaded files with external url, cause we don't know if they're images or not
+      const imagesOnly = this.getCssData('--cfg-img-only');
+      if (!imagesOnly || isImage) {
         return;
       }
-      if (imagesOnly && !isImage) {
-        entry.setValue('validationErrorMsg', this.l10n('images-only-accepted'));
+      if (!entry.getValue('uuid') && entry.getValue('externalUrl')) {
+        // skip validation for not uploaded files with external url, cause we don't know if they're images or not
+        return;
       }
+      if (!entry.getValue('uuid') && !entry.getValue('mimeType')) {
+        // skip validation for not uploaded files without mime-type, cause we don't know if they're images or not
+        return;
+      }
+      entry.setValue('validationErrorMsg', this.l10n('images-only-accepted'));
     });
 
     this._subEntry('externalUrl', (externalUrl) => {

--- a/utils/fileTypes.js
+++ b/utils/fileTypes.js
@@ -31,18 +31,33 @@ export const mergeFileTypes = (fileTypes) => {
 };
 
 /**
- * @param {String} fileType
+ * @param {String} mimeType
  * @param {String[]} allowedFileTypes
  * @returns {Boolean}
  */
-export const matchFileType = (fileType, allowedFileTypes) => {
+export const matchMimeType = (mimeType, allowedFileTypes) => {
   return allowedFileTypes.some((type) => {
     if (type.endsWith('*')) {
       type = type.replace('*', '');
-      return fileType.startsWith(type);
+      return mimeType.startsWith(type);
     }
 
-    return fileType === type;
+    return mimeType === type;
+  });
+};
+
+/**
+ * @param {String} fileName
+ * @param {String[]} allowedFileTypes
+ * @returns {Boolean}
+ */
+export const matchExtension = (fileName, allowedFileTypes) => {
+  return allowedFileTypes.some((type) => {
+    if (!type.startsWith('.')) {
+      return false;
+    }
+
+    return fileName.endsWith(type);
   });
 };
 
@@ -55,5 +70,5 @@ export const fileIsImage = (file) => {
   if (!type) {
     return false;
   }
-  return matchFileType(type, IMAGE_ACCEPT_LIST);
+  return matchMimeType(type, IMAGE_ACCEPT_LIST);
 };

--- a/utils/fileTypes.test.js
+++ b/utils/fileTypes.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { mergeFileTypes, matchFileType, fileIsImage } from './fileTypes';
+import { mergeFileTypes, matchMimeType, fileIsImage, matchExtension } from './fileTypes';
 
 describe('mergeFileTypes', () => {
   it('should join input strings with comma', () => {
@@ -28,15 +28,26 @@ describe('mergeFileTypes', () => {
   });
 });
 
-describe('matchFileType', () => {
+describe('matchMimeType', () => {
   it('should return true if file type is exactly matched', () => {
-    expect(matchFileType('image/jpeg', ['image/jpeg'])).to.be.true;
+    expect(matchMimeType('image/jpeg', ['image/jpeg'])).to.be.true;
   });
   it('should return true if file type is wildcard matched', () => {
-    expect(matchFileType('image/jpeg', ['image/*'])).to.be.true;
+    expect(matchMimeType('image/jpeg', ['image/*'])).to.be.true;
   });
   it('should return false if file type is not matched', () => {
-    expect(matchFileType('text/plain', ['image/*'])).to.be.false;
+    expect(matchMimeType('text/plain', ['image/*'])).to.be.false;
+  });
+});
+
+describe('matchExtension', () => {
+  it('should return true if file extension is exactly matched', () => {
+    expect(matchExtension('image.jpeg', ['.jpeg'])).to.be.true;
+    expect(matchExtension('image.avif', ['.avif'])).to.be.true;
+  });
+  it('should return false if file extension is not matched', () => {
+    expect(matchExtension('image.jpeg', ['.png'])).to.be.false;
+    expect(matchExtension('image.avifs', ['.avif'])).to.be.false;
   });
 });
 


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
