### PR TITLE
fix(cloud-editor): init editor on initCallback instead of connectedCallback to prevent cases when editor init is going before the block init

### DIFF
--- a/blocks/CloudImageEditor/src/CloudEditor.js
+++ b/blocks/CloudImageEditor/src/CloudEditor.js
@@ -65,8 +65,8 @@ export class CloudEditor extends ShadowWrapper {
     this.initEditor();
   }
 
-  connectedCallback() {
-    super.connectedCallback();
+  initCallback() {
+    super.initCallback();
     if (!this.renderShadow) {
       this.initEditor();
     }


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
